### PR TITLE
Handle IBM message consumer thread exit issue.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/ibmmq/source/IBMMessageConsumerThread.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/ibmmq/source/IBMMessageConsumerThread.java
@@ -106,6 +106,8 @@ public class IBMMessageConsumerThread implements Runnable {
             } catch (JMSException e) {
                 throw new IBMMQSourceAdaptorRuntimeException("Exception occurred during consuming messages " +
                         "from the queue: " + e.getMessage(), e);
+            } catch (Throwable t) {
+                logger.error("Exception occurred during consuming messages: " + t.getMessage(), t);
             }
         }
     }


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix the thread issue exist when there are exceptions while reading the events from the queue.

## Goals
> Fix the IMBQ consumer thread exit issue.

## Approach
> Hande the consumer exception, log and continue the consumer process.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Oracle JDK 8

## Learning
> N/A